### PR TITLE
Corrige detecção de erro em objeto no track

### DIFF
--- a/src/Correios/Rastreamento.php
+++ b/src/Correios/Rastreamento.php
@@ -91,6 +91,9 @@ class Rastreamento extends BaseCorreios
     {
         if (! isset($data->error)) {
             if (isset($data->objeto->numero)) {
+                if (isset($data->objeto->erro)) {
+                    throw new FreteException($data->objeto->erro, 0);
+                }
                 $this->result->fill($data->objeto);
 
                 return $this->result;


### PR DESCRIPTION
Dependendo do erro, ele pode estar presente na propriedade objeto. Caso a consulta (e consequentemente o retorno) seja de somente um objeto, é plausível que uma exception seja disparada.