### PR TITLE
Permite definir socket_timeout no rastreamento

### DIFF
--- a/src/Correios/Rastreamento.php
+++ b/src/Correios/Rastreamento.php
@@ -17,6 +17,12 @@ class Rastreamento extends BaseCorreios
     protected $result;
 
     /**
+     * Timeout da requisição ao WS dos Correios
+     * @var int
+     */
+    protected $requestTimeout = 1;
+
+    /**
      * Data
      * @var array
      */
@@ -73,9 +79,29 @@ class Rastreamento extends BaseCorreios
         return $this;
     }
 
+    /**
+     * Get request timeout
+     * @return int
+     */
+    public function getRequestTimeout()
+    {
+        return $this->requestTimeout;
+    }
+
+    /**
+     * Set request timeout
+     * @param int $requestTimeout
+     * @return Rastreamento
+     */
+    public function setRequestTimeout($requestTimeout)
+    {
+        $this->requestTimeout = $requestTimeout;
+        return $this;
+    }
+
     public function track()
     {
-        ini_set('default_socket_timeout', 1);
+        ini_set('default_socket_timeout', $this->requestTimeout);
 
         try {
             $client   = new SoapClient(__DIR__.'/../../resources/Rastro.wsdl');


### PR DESCRIPTION
Os Correios geralmente estão respondendo em bem mais do que 1 segundo no SRO WS. Adicionei a possibilidade de configurar o `default_socket_timeout` na classe `EscapeWork\Frete\Correios\Rastreamento` através do método `setRequestTimeout`. Mantive o default em 1 segundo para evitar BC.